### PR TITLE
feat(ci): run Docker build only on PR to staging

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -19,6 +19,7 @@ jobs:
   docker:
     needs: test-server
     # if: github.ref == 'refs/heads/staging'
+    if: github.event_name == 'pull_request' && github.base_ref == 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
@@ -35,4 +36,4 @@ jobs:
         with:
           push: true
           context: "{{defaultContext}}:backend"
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-backend:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-tgc-v2-backend:latest

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,5 +1,13 @@
 name: backend-tests-workflow
-on: push
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - staging
+
 jobs:
   test-server:
     runs-on: ubuntu-latest
@@ -8,3 +16,23 @@ jobs:
         uses: actions/checkout@v2
       - name: Goto server and run tests
         run: cd backend && npm i && npm test
+  docker:
+    needs: test-server
+    # if: github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push backend image to DockerHub
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: "{{defaultContext}}:backend"
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-backend:latest

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -19,6 +19,7 @@ jobs:
   docker:
     needs: test-client
     # if: github.ref == 'refs/heads/staging'
+    if: github.event_name == 'pull_request' && github.base_ref == 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
@@ -35,4 +36,4 @@ jobs:
         with:
           push: true
           context: "{{defaultContext}}:frontend"
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-frontend:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-tgc-v2-frontend:latest

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,5 +1,13 @@
 name: frontend-tests-workflow
-on: push
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - staging
+
 jobs:
   test-client:
     runs-on: ubuntu-latest
@@ -8,3 +16,23 @@ jobs:
         uses: actions/checkout@v2
       - name: Goto client and run tests
         run: cd frontend && npm i && npm test
+  docker:
+    needs: test-client
+    # if: github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push frontend image to DockerHub
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: "{{defaultContext}}:frontend"
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-frontend:latest


### PR DESCRIPTION
This PR sets up CI/CD workflows to:

Automatically run tests on all branches on every push.

Trigger Docker image build and push only when creating a pull request to staging.

Goal: Prepare the continuous delivery (CD) strategy using Docker Hub.

Docker images pushed:
-   hyna42/app-tgc-v2-frontend
-   hyna42/app-tgc-v2-backend

## Summary by Sourcery

Update CI workflows to run tests on all branches and trigger Docker image builds only for pull requests to the staging branch

CI:
- Modify backend and frontend test workflows to run tests on all branches and push Docker images only when creating a pull request to staging

Deployment:
- Configure Docker Hub image push for backend and frontend images triggered by pull requests to staging branch