### PR TITLE
fix(ci): run docker test only when merge PR

### DIFF
--- a/.github/workflows/full-ci-workflow.yml
+++ b/.github/workflows/full-ci-workflow.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           push: true
           # context: "{{defaultContext}}:frontend"
-          context: ./frontend
+          context: frontend
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-tgc-v2-frontend:latest
   test-server:
     runs-on: ubuntu-latest
@@ -63,5 +63,5 @@ jobs:
         with:
           push: true
           # context: "{{defaultContext}}:backend"
-          context: ./backend
+          context: backend
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-tgc-v2-backend:latest

--- a/.github/workflows/full-ci-workflow.yml
+++ b/.github/workflows/full-ci-workflow.yml
@@ -3,10 +3,8 @@ name: full-ci-workflow
 on:
   push:
     branches:
-      - "**"
-  pull_request:
-    branches:
       - staging
+      - develop
 
 jobs:
   test-client:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Restrict GitHub Actions workflow to run only on pushes to staging and develop branches, removing previous broad branch triggering