### PR TITLE
Update workflow and deploy with short tag

### DIFF
--- a/.github/workflows/full-ci-workflow.yml
+++ b/.github/workflows/full-ci-workflow.yml
@@ -7,16 +7,15 @@ on:
       - develop
 
 jobs:
-  test-client:
+  run-tests-client:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Goto client and run tests
         run: cd frontend && npm i && npm test
-  docker-frontend:
+  build-and-push-client:
     needs: test-client
-    # if: github.event_name == 'pull_request' && github.base_ref == 'staging'
     if: github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
     steps:
@@ -39,22 +38,20 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          # context: "{{defaultContext}}:frontend"
           context: frontend
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/{{ secrets.DOCKERHUB_FRONTEND_IMAGE_NAME }}:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/{{ secrets.DOCKERHUB_FRONTEND_IMAGE_NAME }}:${{ env.SHORT_SHA }}
 
-  test-server:
+  run-tests-server:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Goto server and run tests
         run: cd backend && npm i && npm test
-  docker-backend:
+  build-and-push-server:
     needs: test-server
-    # if: github.event_name == 'pull_request' && github.base_ref == 'staging'
     if: github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
     steps:
@@ -72,7 +69,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          # context: "{{defaultContext}}:backend"
           context: backend
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/{{ secrets.DOCKERHUB_BACKEND_IMAGE_NAME }}:latest

--- a/.github/workflows/full-ci-workflow.yml
+++ b/.github/workflows/full-ci-workflow.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get short commit SHA
+        id: vars
+        run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -36,7 +41,10 @@ jobs:
           push: true
           # context: "{{defaultContext}}:frontend"
           context: frontend
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-tgc-v2-frontend:latest
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/{{ secrets.DOCKERHUB_FRONTEND_IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/{{ secrets.DOCKERHUB_FRONTEND_IMAGE_NAME }}:${{ env.SHORT_SHA }}
+
   test-server:
     runs-on: ubuntu-latest
     steps:
@@ -66,4 +74,6 @@ jobs:
           push: true
           # context: "{{defaultContext}}:backend"
           context: backend
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/app-tgc-v2-backend:latest
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/{{ secrets.DOCKERHUB_BACKEND_IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/{{ secrets.DOCKERHUB_BACKEND_IMAGE_NAME }}:{{ env.SHORT_SHA }}

--- a/.github/workflows/full-ci-workflow.yml
+++ b/.github/workflows/full-ci-workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Goto client and run tests
         run: cd frontend && npm i && npm test
   build-and-push-client:
-    needs: test-client
+    needs: run-tests-client
     if: github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +51,7 @@ jobs:
       - name: Goto server and run tests
         run: cd backend && npm i && npm test
   build-and-push-server:
-    needs: test-server
+    needs: run-tests-server
     if: github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflow to run tests, build and push Docker images with both full and short commit SHA tags on the staging branch

CI:
- Rename test-client/test-server jobs to run-tests-client/run-tests-server
- Rename docker-frontend/backend jobs to build-and-push-client/server with proper dependencies
- Add a step to capture SHORT_SHA as an environment variable
- Push Docker images with both latest and short SHA tags using secret-based image names
- Restrict build-and-push jobs to only trigger on the staging branch