### PR TITLE
fix(ci): add missing DOCKERHUB_IMG  secret for img image build

### DIFF
--- a/.github/workflows/full-ci-workflow.yml
+++ b/.github/workflows/full-ci-workflow.yml
@@ -78,7 +78,7 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_BACKEND_IMAGE_NAME }}:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_BACKEND_IMAGE_NAME }}:${{ env.SHORT_SHA }}
-  
+
   run-tests-img:
     runs-on: ubuntu-latest
     steps:
@@ -88,7 +88,7 @@ jobs:
         run: cd img && npm i && npm test
 
   build-and-push-img:
-    needs: [run-tests-img]
+    needs: run-tests-img
     if: github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
     steps:
@@ -114,5 +114,5 @@ jobs:
           push: true
           context: img
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMG_IMAGE_NAME }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMG_IMAGE_NAME }}:${{ env.SHORT_SHA }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMG }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMG }}:${{ env.SHORT_SHA }}


### PR DESCRIPTION
## Summary by Sourcery

Fix CI workflow to properly build and push the img Docker image

Bug Fixes:
- Use the correct DOCKERHUB_IMG secret instead of DOCKERHUB_IMG_IMAGE_NAME for tagging the img image
- Fix job dependency syntax by changing needs from an array to a single identifier for run-tests-img