### PR TITLE
fix(img): create uploads folder directly in Dockerfile instead of cop…

### DIFF
--- a/img/Dockerfile
+++ b/img/Dockerfile
@@ -1,32 +1,24 @@
 FROM node:lts-alpine
-# Ajoute curl et cron
 
 RUN apk --no-cache add curl dcron
 
 WORKDIR /app
 
-RUN mkdir uploads
+# Préparer dossier uploads directement depuis l'image
+RUN mkdir -p uploads
 
-# Copie des fichiers nécessaires
+# Copier package et installer dépendances
 COPY package.json package-lock.json ./
 RUN npm install
 
-# Copie des fichiers du projet
+# Copier le reste des fichiers du projet
 COPY src src
-COPY uploads uploads
 COPY tsconfig.json tsconfig.json
 COPY clean.ts clean.ts
-
-# Copie des fichiers pour le cron
-COPY crontab /etc/crontabs/root  
+COPY crontab /etc/crontabs/root
 COPY start.sh /app/start.sh
 
 # Rendre le script exécutable
 RUN chmod +x /app/start.sh
 
-
-# Commande à exécuter pour démarrer le backend
-# CMD ["npm","run","start","clean"]
-
-# Commande de démarrage
 CMD ["/app/start.sh"]


### PR DESCRIPTION
…ying

## Summary by Sourcery

Streamline the img Dockerfile to prepare the uploads directory directly and refine the file copy steps

Enhancements:
- Create uploads directory during build using mkdir -p instead of copying from source
- Remove redundant uploads copy directive and adjust copy order of project files
- Update and consolidate Dockerfile comments and formatting for clarity