### PR TITLE
ci(staging): add webhook call to deploy latest Docker images

### DIFF
--- a/.github/workflows/full-ci-workflow.yml
+++ b/.github/workflows/full-ci-workflow.yml
@@ -116,3 +116,11 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMG }}:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMG }}:${{ env.SHORT_SHA }}
+  deploy-staging:
+    needs: [build-and-push-frontend, build-and-push-backend, build-and-push-img]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/staging'
+    steps:
+      - name: Send webhook
+        run: | 
+          curl -X POST https://ops.hyna.me/hooks/${{ secrets.WEBHOOK_ID }}


### PR DESCRIPTION
## Summary by Sourcery

Add a deploy-staging job to the CI workflow that sends a webhook to trigger deployment of the latest Docker images on the staging branch.

CI:
- Add a deploy-staging job that runs only on the staging branch after image builds
- Send a POST request to the configured webhook URL to initiate deployment