### PR TITLE
chore(upload): add API_URL config, vite proxy for local dev, and simp…

### DIFF
--- a/frontend/src/pages/NewAddFormPage.tsx
+++ b/frontend/src/pages/NewAddFormPage.tsx
@@ -14,6 +14,7 @@ import {
 import { GET_ALL_ADS } from "../graphql/queries";
 import { useState } from "react";
 import { useIsLoggedIn } from "../utils/user";
+import { API_URL } from "../utils/config";
 
 export type Category = {
   id: number;
@@ -132,10 +133,11 @@ const NewAddFormPage = () => {
     formData.append("file", file);
 
     try {
-      const response = await axios.post("/img", formData);
+      const response = await axios.post(`${API_URL}/img`, formData);
       if (!response.data.filename) return;
       // Mettre à jour le champ correspondant dans le formulaire
       console.log("filename ==>", response.data.filename);
+      console.log("API_URL ==>", API_URL);
       setValue(`pictures.${index}.url`, response.data.filename);
     } catch (error) {
       console.error("Erreur lors de l'upload de l'image", error);

--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = window.location.origin;

--- a/img/Dockerfile
+++ b/img/Dockerfile
@@ -18,7 +18,7 @@ COPY clean.ts clean.ts
 COPY crontab /etc/crontabs/root
 COPY start.sh /app/start.sh
 
-COPY uploads /app/uploads_seed 
+COPY uploads /app/uploads
 
 # Rendre le script exécutable
 RUN chmod +x /app/start.sh

--- a/img/start.sh
+++ b/img/start.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
 # Initialiser les fichiers dans /app/uploads si c'est vide
-if [ -z "$(ls -A /app/uploads)" ]; then
-  echo "📦 Initialisation des fichiers d'uploads..."
-  cp -r /app/uploads_seed/* /app/uploads/
-fi
+
 
 # Démarrer le service cron en arrière-plan
 crond -b


### PR DESCRIPTION
…lify Dockerfile/start.sh

## Summary by Sourcery

Introduce a dynamic API_URL for frontend upload requests, simplify the upload service startup script by removing seeding logic, and adjust the Dockerfile to copy uploads directly into the application directory.

Enhancements:
- Centralize API base URL in a new config.ts file and use it for image upload requests
- Remove the file-seeding block from the start.sh script
- Add console logging of the API_URL in the upload handler

Build:
- Update Dockerfile to copy the uploads directory directly into /app/uploads instead of using an uploads_seed folder