### PR TITLE
fix(deploy): new Dockerfile for frontend with Nginx + updated nginx.c…

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -15,14 +15,11 @@ services:
       retries: 100
   frontend:
     image: hyna42/app-tgc-v2-frontend
-    environment:
-      - CHOKIDAR_USEPOLLING=true
-      - WATCHPACK_POLLING=true
     depends_on:
       backend:
         condition: service_healthy
     healthcheck:
-      test: "curl --fail --request GET --url 'http://localhost:5173' || exit 1"
+      test: "curl --fail --request GET --url 'http://localhost' || exit 1"
       interval: 1s
       timeout: 2s
       retries: 100

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,26 +1,18 @@
-FROM node:lts-alpine
-
-RUN apk add --no-cache curl
+# Étape 1 : Build du projet React
+FROM node:lts-alpine as builder
 
 WORKDIR /app
 
-# Copie des fichiers de configuration et de dépendances
 COPY package.json package-lock.json ./
 RUN npm install
 
-# Copie des fichiers de l'application
-COPY public public
-COPY src src
+COPY . .
+RUN npm run build
 
-COPY codegen.ts codegen.ts
+# Étape 2 : Nginx pour servir le build
+FROM nginx:alpine
 
-COPY index.html index.html
+COPY --from=builder /app/build /usr/share/nginx/html
 
-COPY tsconfig.app.json tsconfig.app.json
-COPY tsconfig.json tsconfig.json
-COPY tsconfig.node.json tsconfig.node.json
-
-COPY vite.config.ts vite.config.ts
-
-# Commande à exécuter pour démarrer le frontend
-CMD ["npm", "run", "start"]
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
…onf and staging docker-compose

## Summary by Sourcery

Use a multi-stage Docker build to compile and serve the frontend with Nginx, and align the staging compose healthcheck and configuration accordingly

Enhancements:
- Convert frontend Dockerfile to a two-stage build that compiles the React app and serves it as static files with Nginx on port 80

Deployment:
- Remove development‐only polling environment variables from the staging compose configuration
- Update the staging healthcheck to target the Nginx root URL on port 80 instead of the dev server port