### PR TITLE
fix(docker): update Dockerfile to use Vite dist folder for frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
-# Étape 1 : Build du projet React
-FROM node:lts-alpine as builder
+# Étape 1 : Build du frontend (Vite)
+FROM node:lts-alpine AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ RUN npm run build
 # Étape 2 : Nginx pour servir le build
 FROM nginx:alpine
 
-COPY --from=builder /app/build /usr/share/nginx/html
+COPY --from=builder /app/dist /usr/share/nginx/html
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary by Sourcery

Update the frontend Dockerfile to use Vite’s output directory and align stage naming

Bug Fixes:
- Use /app/dist instead of /app/build when copying assets into the Nginx image

Enhancements:
- Adjust Dockerfile comments and stage alias to reference the Vite build process