### PR TITLE
feat(cd): includes static images in img service for staging deployment

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -49,7 +49,7 @@ services:
       timeout: 2s
       retries: 100
     volumes:
-    - ./img/uploads:/app/uploads
+    - uploads:/app/uploads
     env_file:
       - .env
   api_gateway:

--- a/img/Dockerfile
+++ b/img/Dockerfile
@@ -15,7 +15,7 @@ COPY clean.ts clean.ts
 COPY crontab /etc/crontabs/root
 COPY start.sh /app/start.sh
 
-COPY uploads /app/uploads
+COPY uploads/ /app/uploads
 
 # Rendre le script exécutable
 RUN chmod +x /app/start.sh


### PR DESCRIPTION
## Summary by Sourcery

Include static images in the img service for staging by using a named Docker volume for uploads and updating the Dockerfile to copy the uploads folder correctly.

New Features:
- Include static image uploads in the img service for the staging environment

Enhancements:
- Switch the img service’s uploads mount from a host path to a named Docker volume in docker-compose.staging.yml
- Adjust the Dockerfile COPY command to properly include the uploads directory