### PR TITLE
feat(deploy):copy local image in dokcer img for deploying

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -15,6 +15,9 @@ services:
       retries: 100
   frontend:
     image: hyna42/app-tgc-v2-frontend
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+      - WATCHPACK_POLLING=true
     depends_on:
       backend:
         condition: service_healthy
@@ -26,7 +29,7 @@ services:
   db:
     image: postgres
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data # Permet de sauvegarder les données
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USER}
@@ -48,8 +51,9 @@ services:
       interval: 1s
       timeout: 2s
       retries: 100
-    volumes:
-    - uploads:/app/uploads
+    # volumes:
+    #   - ./img/uploads:/app/uploads
+      # - ./img2/clean.ts:/app/clean.ts
     env_file:
       - .env
   api_gateway:
@@ -67,6 +71,3 @@ services:
       - ${GATEWAY_PORT}:80
 volumes:
   postgres_data:
-    name: staging_postgres_data
-  uploads:
-    name: staging_uploads


### PR DESCRIPTION
## Summary by Sourcery

Update staging Docker Compose to enable frontend file polling and streamline volume mounts

Enhancements:
- Add CHOKIDAR_USEPOLLING and WATCHPACK_POLLING environment variables to frontend service
- Comment out uploads volume mount and remove related volume definitions and staging volume names