### PR TITLE
feat(img): run crontab every 15min, ensure db and backend are healthy…

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -51,11 +51,13 @@ services:
       interval: 1s
       timeout: 2s
       retries: 100
-    # volumes:
-    #   - ./img/uploads:/app/uploads
-      # - ./img2/clean.ts:/app/clean.ts
     env_file:
       - .env
+    depends_on:
+      db:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
   api_gateway:
     image: nginx
     volumes:

--- a/frontend/src/components/RecentAds.tsx
+++ b/frontend/src/components/RecentAds.tsx
@@ -28,7 +28,7 @@ const RecentAds = () => {
   return (
     <>
       <main className="main-content">
-        <h2>Annonces récentes Test 2</h2>
+        <h2>Annonces récentes</h2>
         <section className="recent-ads">
           {ads.map((ad) => (
             <div key={ad.id}>

--- a/img/clean.ts
+++ b/img/clean.ts
@@ -30,6 +30,12 @@ import "dotenv/config";
     const dbUrls = response.rows.map((item) => item.url.slice(5));
     // console.log("dbURLs", dbUrls);
 
+    if (!dbUrls.length) {
+      console.log("La DB est vide ou indisponible, skip du nettoyage.");
+      process.exit(0);
+    }
+
+
     //2 liste des urls dans le dossier uploads du service img
     fs.readdir(
       directoryPath,
@@ -54,7 +60,7 @@ import "dotenv/config";
             );
           }
         });
-        if(count)console.log(`❌ ${count} unused files sucessfully removed from /uploads.🗑️🗑️🗑️`);
+        if (count) console.log(`❌ ${count} unused files sucessfully removed from /uploads.🗑️🗑️🗑️`);
       }
     );
   } catch (err) {

--- a/img/crontab
+++ b/img/crontab
@@ -1,1 +1,1 @@
-*/2 * * * * cd /app && npm run clean > /proc/1/fd/1 2>/proc/1/fd/2
+*/15 * * * * cd /app && npm run clean > /proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
… before starting img

## Summary by Sourcery

Ensure the img service runs only after the database and backend are healthy, schedule its cleanup script via crontab every 15 minutes, add a graceful exit when there’s no data to clean, and correct the RecentAds heading in the frontend.

New Features:
- Schedule image cleanup script via crontab to run every 15 minutes.

Bug Fixes:
- Fix RecentAds component heading to remove a "Test 2" placeholder.

Enhancements:
- Require db and backend to be healthy before starting the img service in staging.
- Add early exit in clean.ts when the database has no URLs to clean.

Deployment:
- Update docker-compose staging config to add health-based dependencies for the img service.