### PR TITLE
feat(deploy):exlude upload in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 .env
-uploads


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add ‘upload’ directory to .gitignore to prevent tracking of uploaded files